### PR TITLE
added chat history in memory

### DIFF
--- a/src/app/actions.ts
+++ b/src/app/actions.ts
@@ -4,15 +4,18 @@ export async function getToken() {
     const r = await fetch("https://api.openai.com/v1/realtime/sessions", {
         method: "POST",
         headers: {
-          Authorization: `Bearer ${process.env.OPENAI_API_KEY}`,
-          "Content-Type": "application/json",
+            Authorization: `Bearer ${process.env.OPENAI_API_KEY}`,
+            "Content-Type": "application/json",
         },
         body: JSON.stringify({
-          model: "gpt-4o-realtime-preview-2024-12-17",
-          voice: "verse",
+            model: "gpt-4o-realtime-preview-2024-12-17",
+            voice: "verse",
+            "input_audio_transcription": {
+                "model": "whisper-1"
+            },
         }),
-      });
-      const res = await r.json();
+    });
+    const res = await r.json();
 
-      return res
+    return res
 }


### PR DESCRIPTION
**Reason**

We need to be sure that we can extract transcripts, in order, from the realtime events.

**Solution**

Added a state to capture `item_id`, `previous_item_id`, `role` and `transcript` so we can then persist them in database.